### PR TITLE
Added NVME drive support in DRIVE loop

### DIFF
--- a/templates/autosetup.j2
+++ b/templates/autosetup.j2
@@ -3,7 +3,7 @@ BOOTLOADER {{ bootloader }}
 HOSTNAME {{ inventory_hostname_short }}
 
 # Hard disk drives to wipe and use
-{% for device in ansible_devices if device.startswith("sd") -%}
+{% for device in ansible_devices if device.startswith("sd") or device.startswith("nvme") -%}
   DRIVE{{ loop.index }} /dev/{{ device }}
 {% endfor %}
 


### PR DESCRIPTION
When using the newer NVME SSDs, the `autosetup.j2` template currently does not detect any drives. I added an or condition, might be even better to be able to configure it in a var