### PR TITLE
Allow defining a custom hostname

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,6 @@
+# Test how this is referenced...
+hostname: inventory_hostname_short
+
 # In this weird path you can find official images, but you can use
 # a remote one with http://whatever.tbz2 and similar
 image: /root/.oldroot/nfs/install/../images/Ubuntu-1804-bionic-64-minimal.tar.gz

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
-# Test how this is referenced...
-hostname: inventory_hostname_short
+# Where to reference the hostname from, defaulting to its current short form.
+hostname: "{{ inventory_hostname_short }}"
 
 # In this weird path you can find official images, but you can use
 # a remote one with http://whatever.tbz2 and similar

--- a/templates/autosetup.j2
+++ b/templates/autosetup.j2
@@ -1,6 +1,6 @@
 IMAGE {{ image }}
 BOOTLOADER {{ bootloader }}
-HOSTNAME {{ inventory_hostname_short }}
+HOSTNAME {{ hostname }}
 
 # Hard disk drives to wipe and use
 {% for device in ansible_devices if device.startswith("sd") or device.startswith("nvme") -%}


### PR DESCRIPTION
Instead of always setting a short hostname from the ansible inventory, allow customising it.

Of course defaulting to the original behaviour.