### PR TITLE
Optionally disable automatic reboot after install

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,10 @@
 # a remote one with http://whatever.tbz2 and similar
 image: /root/.oldroot/nfs/install/../images/Ubuntu-1804-bionic-64-minimal.tar.gz
 
+# Automatically reboot after installation?
+# You can disable this if you want to run more commands prior to rebooting.
+reboot_postinstall: false
+
 # Usually you don't need to change this
 bootloader: grub
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,3 +18,5 @@
 - name: reboot into normal mode
   command: reboot
   ignore_errors: true
+  when: reboot_postinstall
+


### PR DESCRIPTION
Our use-case is that we want to have more flexibility customising partitioning.

So we configure simple partitioning in the installimage playbook, and then edit it before rebooting. 

I'm sure there are other use-cases as well :smile: 