### PR TITLE
Optionally define authorized key url

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,10 @@ reboot_postinstall: true
 # Usually you don't need to change this
 bootloader: grub
 
+# You can change this to an URL to automatically add authorized keys
+# to the root user of the installed system
+sshkey_url: false
+
 # Needed to run Docker on XFS; disable setting to false
 # HACK https://github.com/hetzneronline/installimage/pull/8
 xfs_options: "-n ftype=1"

--- a/templates/autosetup.j2
+++ b/templates/autosetup.j2
@@ -1,6 +1,10 @@
 IMAGE {{ image }}
 BOOTLOADER {{ bootloader }}
 HOSTNAME {{ hostname }}
+{% if sshkey_url %}
+# SSH keys to put on the installed system
+SSHKEYS_URL {{ sshkey_url }}
+{% endif %}
 
 # Hard disk drives to wipe and use
 {% for device in ansible_devices if device.startswith("sd") or device.startswith("nvme") -%}


### PR DESCRIPTION
The installimage functionality allows defining a ssh key url to fetch authorized_keys from to install in the root user.

This PR implements that.